### PR TITLE
replace console.log with debug

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@
     var restler = require('restler');
     var validUrl = require('valid-url');
     var util = require('util');
+    var debug = require('debug')('deluge-promise');
 
     var connected = false;
     var isAuthentificated = false;
@@ -80,7 +81,7 @@
 
     function setCookies(cookies, callback) {
         if (cookies !== null && typeof cookies === 'object') {
-            console.log('Setting new cookies');
+            debug('Setting new cookies');
             COOKIE_JAR = cookies;
             callback(null, true);
         } else {
@@ -94,7 +95,7 @@
             auth(function (err, result, response) {
                 if (!err) {
                     SESSION_COOKIE = getCookie(response.headers);
-                    console.log('Authenticate with deluge server...');
+                    debug('Authenticate with deluge server...');
                     isAuthentificated = true;
                 } else {
                     console.error('Problems connecting to deluge: ', err, response.error);
@@ -211,7 +212,7 @@
             // Check if url starts with key, see: http://stackoverflow.com/q/646628/2402914
             if (COOKIE_JAR.hasOwnProperty(key) && url.lastIndexOf(key, 0) === 0) {
                 cookie = COOKIE_JAR[key];
-                console.log("Using cookies for " + key);
+                debug("Using cookies for " + key);
                 break;
             }
         }
@@ -234,7 +235,7 @@
     }
 
     function addTorrent(magnet, dlOptions, callback) {
-        console.log("Adding: " + magnet);
+        debug("Adding: " + magnet);
         post({
             method: 'web.add_torrents',
             params: [[{

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/Zonarius/deluge-promise/issues"
   },
   "dependencies": {
+    "debug": "^3.1.0",
     "restler": "git://github.com/ginman86/restler.git",
     "valid-url": "^1.0.9"
   },


### PR DESCRIPTION
Since this is a library it's a good idea to leave the console clean unless there's an error so this switches the `console.log`s to using [debug](https://github.com/visionmedia/debug).

To enable debug messages just use `DEBUG=deluge-promise` before your script like `DEBUG=deluge-promise node index.js`.